### PR TITLE
render heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 0.0.3 / 2018-07-22
+
+- fix project name to *i-read-u*
+- fix README to use npm install
+
 ## 0.0.2 / 2018-07-22
 
 - add `--file` option

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [Unreleased]
+
+- as abolishing the section question, and made only the command question
+
 ## 0.0.3 / 2018-07-22
 
 - fix project name to *i-read-u*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+## 0.0.2 / 2018-07-22
+
+- add `--file` option
+- add `--version`
+- add tslint and prettier
+
+## 0.0.1 / 2018-07-16
+
+- Initial release

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Extracting commands from README markdown file.
 ## Installation
 
 ```
-$ npm install --global s2terminal/i_read_u
+$ npm install --global i-read-u
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ $ npm install --global s2terminal/i_read_u
 
 ```
 $ ireadu
+$ ireadu --file ./CONTRIBUTING.md
 ```
 
 ### Test Commands (Try ireadu command and hit this)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "i-read-you",
-  "version": "0.0.1",
+  "name": "i-read-u",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1075,10 +1075,9 @@
       "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok="
     },
     "commander": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-      "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
-      "dev": true
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.16.0.tgz",
+      "integrity": "sha512-sVXqklSaotK9at437sFlFpyOcJonxe0yST/AG9DkQKUdIE6IqGIMv4SfAQSKaJbSdVEJYItASCrBiVQHq1HQew=="
     },
     "commondir": {
       "version": "1.0.1",
@@ -4213,6 +4212,12 @@
         "source-map": "~0.6.1"
       },
       "dependencies": {
+        "commander": {
+          "version": "2.13.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
+          "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
+          "dev": true
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "cheerio": "^1.0.0-rc.2",
+    "commander": "^2.16.0",
     "inquirer": "^6.0.0",
     "marked": "^0.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "i-read-you",
   "author": "s2terminal",
   "description": "Extracting commands from README markdown file.",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "bin": {
     "ireadu": "./bin/ireadu.js"
   },

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "i-read-you",
+  "name": "i-read-u",
   "author": "s2terminal",
   "description": "Extracting commands from README markdown file.",
   "version": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
     "url": "https://github.com/s2terminal/i_read_u/issues"
   },
   "homepage": "https://github.com/s2terminal/i_read_u#readme",
+  "keywords": [
+    "README", "markdown", "command", "parser"
+  ],
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "i-read-u",
   "author": "s2terminal",
   "description": "Extracting commands from README markdown file.",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "bin": {
     "ireadu": "./bin/ireadu.js"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ function htmlToCommands(html: string): { [key: string]: string[] } {
             if (!commands[key]) {
               commands[key] = [];
             }
-            commands[key].push(command.replace(/^[#>\s\$]+/, ""));
+            commands[key].push(command.replace(/^[#>\s\$]*/, " "));
           });
       }
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,8 @@ function htmlToCommands(html: string): { [key: string]: string[] } {
     .map(e => {
       const $e = cheerio(e);
       if ($e.is("h1,h2,h3,h4,h5,h6")) {
-        key = $e.text();
+        const heading: number = +$e.get(0).tagName.substr(1, 1);
+        key = `${"#".repeat(heading)} ${$e.text()}`;
       }
       if (key && $e.is("code")) {
         $e.text()

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,32 +42,26 @@ function htmlToCommands(html: string): { [key: string]: string[] } {
 }
 
 function executeCommands(commands: { [key: string]: string[] }) {
-  const section = "section";
-  const questionSection = {
-    type: "list",
-    name: section,
-    message: "choice section",
-    choices: Object.keys(commands)
-  };
-  inquirer.prompt([questionSection]).then(answerSections => {
-    const command = "command";
-    const questionCommand = {
-      type: "list",
-      name: command,
-      message: "choice command",
-      choices: commands[answerSections[section]]
-    };
-    inquirer.prompt([questionCommand]).then(answerCommands => {
-      child_process.exec(answerCommands[command], (error, stdout, stderr) => {
-        console.log(stdout);
-        if (error) {
-          console.error(error);
-        }
-        if (stderr) {
-          console.error(stderr);
-        }
-      });
+  const command = "command";
+  const commandChoices = [];
+
+  Object.keys(commands).forEach(sect => {
+    commandChoices.push(new inquirer.Separator(sect));
+    commands[sect].forEach(cmd => {
+      commandChoices.push(cmd);
     });
+  });
+
+  const questionCommand = {
+    type: "list",
+    name: command,
+    message: "choice section",
+    choices: commandChoices
+  };
+  inquirer.prompt([questionCommand]).then(answerCommands => {
+    const cmd = child_process.exec(answerCommands[command]);
+    cmd.stdout.pipe(process.stdout);
+    cmd.stderr.pipe(process.stderr);
   });
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,7 @@ function executeCommands(commands: { [key: string]: string[] }) {
   const questionCommand = {
     type: "list",
     name: command,
-    message: "choice section",
+    message: "choice command",
     choices: commandChoices
   };
   inquirer.prompt([questionCommand]).then(answerCommands => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import * as child_process from "child_process";
 import * as fs from "fs";
 import * as inquirer from "inquirer";
 import * as marked from "marked";
+const program = require("commander");
 
 function markdownToHtml(filepath: string): string {
   let html: string;
@@ -71,7 +72,13 @@ function executeCommands(commands: { [key: string]: string[] }) {
 }
 
 function main() {
-  const html = markdownToHtml("README.md");
+  const packagejson = require("../package.json");
+
+  program.option("--file <filename>", "Specify the file name", "README.md");
+  program.version(packagejson.version);
+
+  program.parse(process.argv);
+  const html = markdownToHtml(program.file);
   const commands = htmlToCommands(html);
   executeCommands(commands);
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
     "module": "es2015",
-    "target": "es5",
+    "target": "es2015"
   }
 }


### PR DESCRIPTION
- abolished section question
- render `#` charactors as heading

e.g.
```
? choice command (Use arrow keys)
  ## Installation
❯  npm install --global i-read-u
  ## Usage
   ireadu
   ireadu --file ./CONTRIBUTING.md
  ### Test Commands (Try ireadu command and hit this)
   ls
(Move up and down to reveal more choices)
```