### PR TITLE
Webpack size

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Extracting commands from README markdown file.
 $ npm install --global i-read-u
 ```
 
+### Requirements
+Node.js v6.0+
+
 ## Usage
 ```bash
 $ ireadu

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ $ ls
 git clone and run this.
 ```bash
 $ npm install --save-dev
-$ npm run watch
+$ npm run webpack-watch
 $ bin/ireadu.js
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1382,6 +1382,12 @@
         "domelementtype": "1"
       }
     },
+    "duplexer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+      "dev": true
+    },
     "duplexify": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
@@ -2391,6 +2397,16 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
       "dev": true
+    },
+    "gzip-size": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.0.0.tgz",
+      "integrity": "sha512-5iI7omclyqrnWw4XbXAmGhPsABkSIDQonv2K0h61lybgofWa6iZyvrI3r2zsJH4P8Nb64fFVzlvfhs0g7BBxAA==",
+      "dev": true,
+      "requires": {
+        "duplexer": "^0.1.1",
+        "pify": "^3.0.0"
+      }
     },
     "has-ansi": {
       "version": "2.0.0",
@@ -3404,6 +3420,12 @@
       "integrity": "sha512-KtQ2EGaUwf2EyDfp1fxyEb0PqGKakVm0WyXwDt6u+cAoxbO2Z2CwKvOe3+b4+F2IlO9lYHi1kqFuRM70ddBnow==",
       "dev": true
     },
+    "pretty-bytes": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.1.0.tgz",
+      "integrity": "sha512-wa5+qGVg9Yt7PB6rYm3kXlKzgzgivYTLRandezh43jjRqgyDyP+9YxfJpJiLs9yKD1WeU8/OvtToWpW7255FtA==",
+      "dev": true
+    },
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -3776,6 +3798,20 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "size-plugin": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/size-plugin/-/size-plugin-1.0.0.tgz",
+      "integrity": "sha512-YyjJ/V3Zk/p9fpg9VYUjT3FMwT6iIq+OucBvd8DnOGfuFK1PgQ4gPO6TmmSCRa264wfgpEvor3HPzwY2hBjmYg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.1",
+        "escape-string-regexp": "^1.0.5",
+        "glob": "^7.1.2",
+        "gzip-size": "^5.0.0",
+        "minimatch": "^3.0.4",
+        "pretty-bytes": "^5.1.0"
+      }
     },
     "snapdragon": {
       "version": "0.8.2",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "main": "./bin/ireadu.js",
   "scripts": {
     "prepare": "webpack --config webpack.common.js",
-    "build": "webpack --config webpack.common.js",
-    "watch": "webpack --config webpack.dev.js --watch",
+    "webpack-watch": "webpack --config webpack.dev.js --watch",
+    "webpack-size": "webpack --config webpack.dev.js -p",
     "exec": "node dist/main.js",
     "lint": "tslint --config tslint.json src/index.ts",
     "lint:fix": "tslint --config tslint.json --fix src/index.ts"
@@ -22,6 +22,7 @@
     "@types/node": "^10.5.6",
     "prettier": "^1.14.0",
     "shebang-loader": "0.0.1",
+    "size-plugin": "^1.0.0",
     "ts-loader": "^4.4.2",
     "tslint": "^5.11.0",
     "tslint-config-prettier": "^1.14.0",
@@ -46,7 +47,10 @@
   },
   "homepage": "https://github.com/s2terminal/i_read_u#readme",
   "keywords": [
-    "README", "markdown", "command", "parser"
+    "README",
+    "markdown",
+    "command",
+    "parser"
   ],
   "license": "MIT"
 }

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,6 +1,11 @@
 const merge = require('webpack-merge');
 const common = require('./webpack.common.js');
+const SizePlugin = require('size-plugin');
+
 module.exports = merge(common, {
   mode: 'development',
   devtool: 'inline-source-map',
+  plugins: [
+    new SizePlugin()
+  ]
 });


### PR DESCRIPTION
- add webpack-size-plugin
    - GoogleChromeLabs/size-plugin: Track compressed Webpack asset sizes over time. https://github.com/GoogleChromeLabs/size-plugin
- remove `npm run build` script
- add `npm run webpack-size` script
- specify that requires Node.js version 6.0 or higher